### PR TITLE
Make compile script Heroku + Scalingo compatible

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -42,14 +42,14 @@ mkdir -p "$APT_STATE_DIR/lists/partial"
 APT_OPTIONS="-o debug::nolocking=true -o dir::cache=$APT_CACHE_DIR -o dir::state=$APT_STATE_DIR"
 
 case "$STACK" in
-  "scalingo-14")
+  "cedar-14" | "scalingo-14" | "scalingo-18")
     APT_FLAGS="--force-yes"
     ;;
-  "scalingo-18" | "scalingo-20")
+  "heroku-16" | "heroku-18" | "heroku-20")
     APT_FLAGS="--allow-downgrades --allow-remove-essential --allow-change-held-packages"
     ;;
   *)
-    error "STACK must be 'scalingo-14', 'scalingo-18', or 'scalingo-20'"
+    error "STACK must be 'scalingo-14', 'scalingo-18', 'cedar-14', 'heroku-16', or 'heroku-18'"
 esac
 
 topic "Updating apt caches"


### PR DESCRIPTION
@scalingo team suggests setting environment variable `STACK=cedar-14` for the build pack to work on their `scalingo-18` stack.

This change makes the buildpack use the same `APT_FLAGS` as Heroku's `cedar-14` on Scalingo's `scalingo-18` without setting the `STACK` environment variable.